### PR TITLE
Unref all refs to prevent hydration error.

### DIFF
--- a/src/runtime/useFetch.ts
+++ b/src/runtime/useFetch.ts
@@ -4,7 +4,8 @@ import type { $Fetch } from 'ofetch'
 import type { Ref } from 'vue'
 import type { FetchResponseData, FetchResponseError, FilterMethods, ParamsOption, RequestBodyOption } from './fetch'
 import { useFetch, useNuxtApp } from 'nuxt/app'
-import { hash } from 'ohash'
+import { digest } from 'ohash'
+import { toValue } from 'vue'
 
 type PickFrom<T, K extends Array<string>> = T extends Array<any> ? T : T extends Record<string, any> ? keyof T extends K[number] ? T : K[number] extends never ? T : Pick<T, K[number]> : T
 type KeysOf<T> = Array<T extends T ? keyof T extends string ? keyof T : never : never>
@@ -64,15 +65,7 @@ export function createUseOpenFetch<
     const nuxtApp = useNuxtApp()
     const fetch = (typeof client === 'string' ? nuxtApp[`$${client}`] : client) as typeof $fetch
 
-    // Temporary solution for duplicated requests
-    const key = hash({
-      url: (typeof url === 'string' ? url : url()),
-      method: options.method,
-      path: options.path,
-      query: options.query,
-      body: options.body,
-    })
-
+    const key = options.key ?? createAutoKey(url, options)
     const opts = { $fetch: fetch, key, ...options }
     if (opts.header) {
       opts.headers = opts.header
@@ -80,4 +73,19 @@ export function createUseOpenFetch<
     }
     return useFetch(url, lazy ? { ...opts, lazy } : { ...opts })
   }
+}
+
+function createAutoKey(url: string | (() => string), options: any) {
+  const resolvedRequestOptions = {
+    url: typeof url === 'string' ? url : url(),
+    method: options.method,
+    path: options.path,
+    query: options.query,
+    body: options.body,
+  }
+
+  // Convert to json string and use a custom replacer function to unref all refs.
+  const resolvedRequestOptionsJson = JSON.stringify(resolvedRequestOptions, (_, value) => toValue(value))
+
+  return digest(resolvedRequestOptionsJson)
 }

--- a/src/runtime/useFetch.ts
+++ b/src/runtime/useFetch.ts
@@ -77,7 +77,7 @@ export function createUseOpenFetch<
 
 function createAutoKey(url: string | (() => string), options: any) {
   const resolvedRequestOptions = {
-    url: typeof url === 'string' ? url : url(),
+    url,
     method: options.method,
     path: options.path,
     query: options.query,


### PR DESCRIPTION
I very often get an hydration error when I use a Ref value as query property value.
Like so:
```vue
<script setup lang="ts">
const paginationState = ref({
  pageIndex: 0,
  pageSize: 20,
});

const { data: items} = await useAdmin(
  '/api/items',
  {
    method: 'GET',
    query: {
      Limit: toRef(() => paginationState.value.pageSize),
      Offset: computed(
        () => paginationState.value.pageSize * paginationState.value.pageIndex,
      ),
    },
  },
);
</script>
```
This seem to happen consistently with ComputedRef values. The server side produces a different hash each time
```ts
import { hash } from 'ohash';

console.log(hash(computed(() => 1)));
```

This pr makes it so the config option is converted to Json, using a custom replacer function that unrefs all ref values, before hashing it. This seems to solve the problem.